### PR TITLE
closes #88 webhookでエラーが出た時の対応

### DIFF
--- a/controllers/repositories_controller.go
+++ b/controllers/repositories_controller.go
@@ -26,6 +26,7 @@ func (u *Repositories) Hook(c web.C, w http.ResponseWriter, r *http.Request) {
 
 	if eventType == "" || signature == "" || deliveryID == "" {
 		logging.SharedInstance().MethodInfo("Repositories", "Hook").Infof("could not find header information: %v", r.Header)
+		http.Error(w, "event, signature, or delivery_id is not exist", 404)
 		return
 	}
 
@@ -39,13 +40,19 @@ func (u *Repositories) Hook(c web.C, w http.ResponseWriter, r *http.Request) {
 		repo := repository.FindRepositoryByRepositoryID(id)
 		if repo == nil {
 			logging.SharedInstance().MethodInfo("Repositories", "Hook").Error("could not find repository")
+			http.Error(w, "repository not found", 404)
 			return
 		}
 		if !repo.Authenticate(signature, data) {
 			logging.SharedInstance().MethodInfo("Repositories", "Hook").Info("cannot authenticate to repository")
+			http.Error(w, "repository authenticate failed", 404)
 			return
 		}
-		project.IssuesEvent(repo.ID, githubBody)
+		err := project.IssuesEvent(repo.ID, githubBody)
+		if err != nil {
+			http.Error(w, "Internal Server Error", 500)
+			return
+		}
 
 	case "pull_request":
 		var githubBody github.PullRequestEvent
@@ -56,12 +63,20 @@ func (u *Repositories) Hook(c web.C, w http.ResponseWriter, r *http.Request) {
 		repo := repository.FindRepositoryByRepositoryID(id)
 		if repo == nil {
 			logging.SharedInstance().MethodInfo("Repositories", "Hook").Error("could not find repository")
+			http.Error(w, "repository not found", 404)
 			return
 		}
 		if !repo.Authenticate(signature, data) {
 			logging.SharedInstance().MethodInfo("Repositories", "Hook").Info("cannot authenticate to repository")
+			http.Error(w, "repository authenticate failed", 404)
 			return
 		}
-		project.PullRequestEvent(repo.ID, githubBody)
+		err := project.PullRequestEvent(repo.ID, githubBody)
+		if err != nil {
+			http.Error(w, "Internal Server Error", 500)
+			return
+		}
 	}
+
+	return
 }

--- a/models/project/github.go
+++ b/models/project/github.go
@@ -159,6 +159,7 @@ func (u *ProjectStruct) createNewTask(issue *github.Issue) error {
 	}
 	if !issueTask.Save(nil, nil) {
 		logging.SharedInstance().MethodInfo("Project", "createNewTask", true).Error("task save failed")
+		return errors.New("task save failed")
 	}
 	return nil
 


### PR DESCRIPTION
- [x] webhookでもエラーの時はエラーレスポンスを返す

二重通知は良くないかと思ったが，別に同一なものであると明示されていればいいのでは？
むしろ拾えないパターンがあるのが怖い．
もし必要であるなら，これは全体的な設計の問題で，モデル層のメソッドと，コントローラ層のメソッドで，それぞれエラー通知をしているのが問題なので，そこを改善したほうがいい．
根源的に考えると，コントローラ層でのエラー通知はいらないのでは？っていう気がするが，もしもモデル層の通知で抜け落ちていたらやばいね．
ただ，予期せぬpanicは拾えるようになったので，もうその方向でいいのかもしれないと，固まりつつある．
いずれにしろ別ぷるりで対応する．