### PR TITLE
closes #116 同時webhookでエラーが出ないようにする

### DIFF
--- a/models/task/task.go
+++ b/models/task/task.go
@@ -100,16 +100,16 @@ func (u *TaskStruct) Save(repo *repository.RepositoryStruct, OauthToken *sql.Nul
 	count := 0
 	err := transaction.QueryRow("SELECT COUNT(id) FROM tasks WHERE list_id = ?;", u.ListID).Scan(&count)
 	if err != nil {
-		panic(err)
 		transaction.Rollback()
 		return err
 	}
 	result, err := transaction.Exec("insert into tasks (list_id, project_id, user_id, issue_number, title, description, pull_request, html_url, display_index, created_at) values (?,?,?, ?, ?, ?, ?, ?, ?, now());", u.ListID, u.ProjectID, u.UserID, u.IssueNumber, u.Title, u.Description, u.PullRequest, u.HTMLURL, count+1)
-	currentID, _ := result.LastInsertId()
 	if err != nil {
 		transaction.Rollback()
 		return err
 	}
+	currentID, _ := result.LastInsertId()
+
 	if OauthToken != nil && OauthToken.Valid && repo != nil {
 		var listTitle, listColor sql.NullString
 		var listOptionID sql.NullInt64


### PR DESCRIPTION
おそらく，以前対策したduplicate entryが原因である．
ただ，あの対策をしたあとに，task#saveをリファクタリングし，意図しない位置にLastInsertID取得メソッドが入っている．これが，エラーハンドリングより手前に入っているために，runtimeエラーになっているのではないかと推測される．

手元での再現時に，詳しいスタックトレースを出したところ，このLastInsertIDのメソッド呼び出し部分がひっかかっていたので，おそらくこれで確定．
よってこの対応で問題なく解消するはず．