### PR TITLE
closes #204 taskのバリデーションで本文の長さを21845まで伸ばす

### DIFF
--- a/validators/task_validator.go
+++ b/validators/task_validator.go
@@ -6,7 +6,7 @@ import (
 
 type taskCreate struct {
 	Title       string `valid:"stringlength(1|255)"`
-	Description string `valid:"stringlength(0|255),optional"`
+	Description string `valid:"stringlength(0|21845),optional"`
 }
 
 type taskMove struct {


### PR DESCRIPTION
カラムの定義変更はTEXT型なので難しい，カラム側に文字列長指定ができない．
というわけで3バイト文字が入る分まで伸ばす．